### PR TITLE
Fix duplicate token handling in LCSMatch

### DIFF
--- a/spellpy/spell.py
+++ b/spellpy/spell.py
@@ -126,7 +126,7 @@ class LogParser(pickle.Unpickler):
         size_seq = len(seq)
         for LCSObject in LCSMap:
             set_template = set(LCSObject.logTemplate)
-            if len(set_seq & set_template) < 0.5 * size_seq:
+            if len(set_seq & set_template) < 0.5 * len(set_seq):
                 continue
             lcs = self.LCS(seq, LCSObject.logTemplate)
             if len(lcs) > maxLen or (len(lcs) == maxLen and len(LCSObject.logTemplate) < len(maxLCSObject.logTemplate)):

--- a/tests/test_spellpy.py
+++ b/tests/test_spellpy.py
@@ -94,6 +94,15 @@ class TestLogParser(unittest.TestCase):
         new_template = self.parser.getTemplate(lcs, seq)
         self.assertListEqual(new_template, expected_template)
 
+    def test_LCSMatch_duplicate_tokens(self):
+        seq = ['a'] * 76
+        logmessageL = ['a'] * 76
+        newCluster = LCSObject(logTemplate=logmessageL, logIDL=[0])
+
+        ret = self.parser.LCSMatch([newCluster], seq)
+        self.assertIsNotNone(ret)
+        self.assertListEqual(ret.logTemplate, newCluster.logTemplate)
+
 
 def helper(rootNode):
     if rootNode.childD == dict():


### PR DESCRIPTION
## Summary
- correct token overlap threshold so templates with repeated tokens are matched
- add regression test to ensure LCSMatch works with duplicate tokens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6882f0b64d9083278645032787cbc9a0